### PR TITLE
New --tinygo-args

### DIFF
--- a/cmd/function/build.go
+++ b/cmd/function/build.go
@@ -20,6 +20,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"path"
+	"time"
+
 	"github.com/loopholelabs/cmdutils"
 	"github.com/loopholelabs/cmdutils/pkg/command"
 	"github.com/loopholelabs/cmdutils/pkg/printer"
@@ -32,8 +35,6 @@ import (
 	"github.com/loopholelabs/scalefile/scalefunc"
 	"github.com/posthog/posthog-go"
 	"github.com/spf13/cobra"
-	"path"
-	"time"
 )
 
 // BuildCmd encapsulates the commands for building Functions
@@ -46,6 +47,7 @@ func BuildCmd(hidden bool) command.SetupCommand[*config.Config] {
 	var goBin string
 	var tinygo string
 	var cargo string
+	var tinygoArgs []string
 
 	return func(cmd *cobra.Command, ch *cmdutils.Helper[*config.Config]) {
 		buildCmd := &cobra.Command{
@@ -100,7 +102,7 @@ func BuildCmd(hidden bool) command.SetupCommand[*config.Config] {
 				}
 
 				end := ch.Printer.PrintProgress(fmt.Sprintf("Building scale function %s:%s...", scaleFile.Name, scaleFile.Tag))
-				scaleFunc, err := build.LocalBuild(scaleFile, goBin, tinygo, cargo, directory)
+				scaleFunc, err := build.LocalBuild(scaleFile, goBin, tinygo, cargo, directory, tinygoArgs)
 				end()
 				if err != nil {
 					return fmt.Errorf("failed to build scale function: %w", err)
@@ -162,6 +164,7 @@ func BuildCmd(hidden bool) command.SetupCommand[*config.Config] {
 		buildCmd.Flags().StringVarP(&tag, "tag", "t", "", "the (optional) tag of this scale function")
 		buildCmd.Flags().StringVarP(&org, "org", "o", "", "the (optional) organization of this scale function")
 
+		buildCmd.Flags().StringSliceVar(&tinygoArgs, "tinygo-args", []string{"-scheduler=none", "--no-debug", "main.go"}, "list of (optional) tinygo build arguments")
 		buildCmd.Flags().StringVar(&tinygo, "tinygo", "", "the (optional) path to the tinygo binary")
 		buildCmd.Flags().StringVar(&goBin, "go", "", "the (optional) path to the go binary")
 		buildCmd.Flags().StringVar(&cargo, "cargo", "", "the (optional) path to the cargo binary")

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -19,14 +19,15 @@ package build
 import (
 	"errors"
 	"fmt"
-	"github.com/loopholelabs/scale/go/compile"
-	rustCompile "github.com/loopholelabs/scale/rust/compile"
-	"github.com/loopholelabs/scalefile"
-	"github.com/loopholelabs/scalefile/scalefunc"
 	"io"
 	"os"
 	"os/exec"
 	"path"
+
+	"github.com/loopholelabs/scale/go/compile"
+	rustCompile "github.com/loopholelabs/scale/rust/compile"
+	"github.com/loopholelabs/scalefile"
+	"github.com/loopholelabs/scalefile/scalefunc"
 )
 
 var (
@@ -41,7 +42,7 @@ type Module struct {
 	Signature string
 }
 
-func LocalBuild(scaleFile *scalefile.ScaleFile, goBin string, tinygo string, cargo string, baseDir string) (*scalefunc.ScaleFunc, error) {
+func LocalBuild(scaleFile *scalefile.ScaleFile, goBin string, tinygo string, cargo string, baseDir string, tinygoArgs []string) (*scalefunc.ScaleFunc, error) {
 	scaleFunc := &scalefunc.ScaleFunc{
 		Version:   scalefunc.V1Alpha,
 		Name:      scaleFile.Name,
@@ -189,7 +190,9 @@ func LocalBuild(scaleFile *scalefile.ScaleFile, goBin string, tinygo string, car
 			return nil, fmt.Errorf("unable to compile scale function: %w", err)
 		}
 
-		cmd = exec.Command(tinygo, "build", "-o", "scale.wasm", "-scheduler=none", "-target=wasi", "--no-debug", "main.go")
+		tinygoArgs = append([]string{"build", "-o", "scale.wasm", "-target=wasi"}, tinygoArgs...)
+
+		cmd = exec.Command(tinygo, tinygoArgs...)
 		cmd.Dir = path.Join(wd, buildDir)
 
 		output, err = cmd.CombinedOutput()


### PR DESCRIPTION
New argument --tinygo-args who can receive a list of arguments to tinygo build.

I kept "build -o scale.wasm -target=wasi" always preceding passed arguments, because they are mandatory

Found no tests in repository, so i did manual tests and i was able to reproduce *Get Started* and execute goroutines from scale functions

This fix following issue by passing --tinygo-args=-scheduler=asyncify: https://github.com/loopholelabs/scale/issues/91