### PR TITLE
Added tracing relay to otel receiver

### DIFF
--- a/cmd/function/run.go
+++ b/cmd/function/run.go
@@ -162,7 +162,7 @@ func RunCmd(hidden bool) command.SetupCommand[*config.Config] {
 									ch.Printer.Printf("error sending trace data [%s]: %v\n", s, printer.BoldRed(err))
 								} else {
 									if res.StatusCode != 200 {
-										ch.Printer.Printf("error sending trace data [%s]: %d\n", s, printer.BoldRed(res.StatusCode))
+										ch.Printer.Printf("error sending trace data [%s]: %s\n", s, printer.BoldRed(res.StatusCode))
 									} else {
 										// OK, trace was sent successfully.
 									}

--- a/cmd/function/run.go
+++ b/cmd/function/run.go
@@ -17,7 +17,15 @@
 package function
 
 import (
+	"bytes"
 	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
 	"github.com/loopholelabs/cmdutils"
 	"github.com/loopholelabs/cmdutils/pkg/command"
 	"github.com/loopholelabs/cmdutils/pkg/printer"
@@ -25,24 +33,20 @@ import (
 	"github.com/loopholelabs/scale-cli/cmd/utils"
 	"github.com/loopholelabs/scale-cli/internal/config"
 	adapter "github.com/loopholelabs/scale-http-adapters/fasthttp"
-	"github.com/loopholelabs/scale/go"
+	runtime "github.com/loopholelabs/scale/go"
 	"github.com/loopholelabs/scale/go/registry"
 	"github.com/loopholelabs/scale/go/storage"
 	"github.com/loopholelabs/scalefile/scalefunc"
 	"github.com/posthog/posthog-go"
 	"github.com/spf13/cobra"
 	"github.com/valyala/fasthttp"
-	"os"
-	"os/signal"
-	"sync"
-	"syscall"
-	"time"
 )
 
 // RunCmd encapsulates the commands for running Functions
 func RunCmd(hidden bool) command.SetupCommand[*config.Config] {
 	return func(cmd *cobra.Command, ch *cmdutils.Helper[*config.Config]) {
 		var listen string
+		var tracingServer string
 		runCmd := &cobra.Command{
 			Use:      "run [ ...[ <name>:<tag> ] | [ <org>/<name>:<tag> ] ] [flags]",
 			Args:     cobra.MinimumNArgs(1),
@@ -138,6 +142,38 @@ func RunCmd(hidden bool) command.SetupCommand[*config.Config] {
 					return fmt.Errorf("failed to create runtime: %w", err)
 				}
 
+				if tracingServer != "" {
+					const TRACING_MAX_CONCURRENCY = 8
+					var client = http.Client{}
+					var limiter = make(chan bool, TRACING_MAX_CONCURRENCY)
+					var url = fmt.Sprintf("http://%s/v1/traces", tracingServer)
+					r.TraceDataCallback = func(s string) {
+						// Don't delay the scale function...
+						go func() {
+							limiter <- true
+							r, err := http.NewRequest("POST", url, bytes.NewBuffer([]byte(s)))
+							if err != nil {
+								ch.Printer.Printf("error sending trace data: %v\n", printer.BoldRed(err))
+							} else {
+								r.Header.Add("Content-Type", "application/json")
+
+								res, err := client.Do(r)
+								if err != nil {
+									ch.Printer.Printf("error sending trace data [%s]: %v\n", s, printer.BoldRed(err))
+								} else {
+									if res.StatusCode != 200 {
+										ch.Printer.Printf("error sending trace data [%s]: %d\n", s, printer.BoldRed(res.StatusCode))
+									} else {
+										// OK, trace was sent successfully.
+									}
+								}
+							}
+							<-limiter
+						}()
+					}
+					ch.Printer.Printf("Sending Otel traces to %s\n", printer.BoldGreen(tracingServer))
+				}
+
 				stop := make(chan os.Signal, 1)
 				signal.Notify(stop, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
 
@@ -168,6 +204,7 @@ func RunCmd(hidden bool) command.SetupCommand[*config.Config] {
 		}
 
 		runCmd.Flags().StringVarP(&listen, "listen", "l", ":8080", "the address to listen on")
+		runCmd.Flags().StringVarP(&tracingServer, "tracing", "t", "", "Otel tracing server to send traces to")
 		cmd.AddCommand(runCmd)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/loopholelabs/cmdutils v0.1.2
 	github.com/loopholelabs/polyglot-go v0.5.1
 	github.com/loopholelabs/releaser v0.1.1
-	github.com/loopholelabs/scale v0.3.18
+	github.com/loopholelabs/scale v0.3.19
 	github.com/loopholelabs/scale-http-adapters v0.3.8
 	github.com/loopholelabs/scale-signature v0.2.11
 	github.com/loopholelabs/scalefile v0.1.9

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/loopholelabs/cmdutils v0.1.2
 	github.com/loopholelabs/polyglot-go v0.5.1
 	github.com/loopholelabs/releaser v0.1.1
-	github.com/loopholelabs/scale v0.3.17
+	github.com/loopholelabs/scale v0.3.18
 	github.com/loopholelabs/scale-http-adapters v0.3.8
 	github.com/loopholelabs/scale-signature v0.2.11
 	github.com/loopholelabs/scalefile v0.1.9

--- a/go.sum
+++ b/go.sum
@@ -273,8 +273,8 @@ github.com/loopholelabs/polyglot-go v0.5.1 h1:21QVDELp+EodPUAL+Aw8GNXLyt2BFj9gYQ
 github.com/loopholelabs/polyglot-go v0.5.1/go.mod h1:Z0QiNv4KRuWjQWpUerMhmkvRh6ks1pYmEH4SGpG0EHQ=
 github.com/loopholelabs/releaser v0.1.1 h1:o8Z4jIR4TcaSRiwFpAGIJSAkAUOxlXL1ML3EscGqxDU=
 github.com/loopholelabs/releaser v0.1.1/go.mod h1:51hV+lDDYeJNzeVOZCQnGS5cJN8ODg/V5AxYtiL67UA=
-github.com/loopholelabs/scale v0.3.17 h1:slIt+LhrCQikFSIGWxATNHrBjDtnj7EojCK+WzHNuNA=
-github.com/loopholelabs/scale v0.3.17/go.mod h1:TXIiUBjvIK5+HFCwtGNzkPNBlDbNKHJPAIUBVbUGDas=
+github.com/loopholelabs/scale v0.3.19 h1:IJF1MZiUaIDSw+szh2fB15BO4d3LAFTAwCmaceV5NAI=
+github.com/loopholelabs/scale v0.3.19/go.mod h1:TXIiUBjvIK5+HFCwtGNzkPNBlDbNKHJPAIUBVbUGDas=
 github.com/loopholelabs/scale-http-adapters v0.3.8 h1:tngPE+qbZ85hQCz0c+8jR/JC6fFpAWzRZEP4reaqUtA=
 github.com/loopholelabs/scale-http-adapters v0.3.8/go.mod h1:1Ft0XdrF1mt44xg8oBCTMRiLjlAJ5m0QGJu+mAt3eDY=
 github.com/loopholelabs/scale-signature v0.2.11 h1:Wnur2owfIsuOFDzJTiwRd8rCJRBOzWRYK29ORr6XVYo=


### PR DESCRIPTION
This change adds optional relay of tracing data from go scale host to an otel receiver host.
For example `./scale-cli run go-hello:latest --tracing localhost:4318`
