### PR TITLE
Jm/tracing build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/klauspost/compress v1.15.9 // indirect
 	github.com/lensesio/tableprinter v0.0.0-20201125135848-89e81fc956e7 // indirect
 	github.com/loopholelabs/scale-signature-http v0.3.8 // indirect
-	github.com/loopholelabs/wasm-toolkit v0.0.2 // indirect
+	github.com/loopholelabs/wasm-toolkit v0.0.3 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/posthog/posthog-go v0.0.0-20221221115252-24dfed35d71a
 	github.com/rs/zerolog v1.29.0
-	github.com/spf13/cobra v1.6.1
+	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/valyala/fasthttp v1.44.0
 )
@@ -53,13 +53,14 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/kataras/tablewriter v0.0.0-20180708051242-e063d29b7c23 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/klauspost/compress v1.15.9 // indirect
 	github.com/lensesio/tableprinter v0.0.0-20201125135848-89e81fc956e7 // indirect
 	github.com/loopholelabs/scale-signature-http v0.3.8 // indirect
+	github.com/loopholelabs/wasm-toolkit v0.0.2 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/loopholelabs/scale-http-adapters v0.3.8
 	github.com/loopholelabs/scale-signature v0.2.11
 	github.com/loopholelabs/scalefile v0.1.9
+	github.com/loopholelabs/wasm-toolkit v0.0.3
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
@@ -60,7 +61,6 @@ require (
 	github.com/klauspost/compress v1.15.9 // indirect
 	github.com/lensesio/tableprinter v0.0.0-20201125135848-89e81fc956e7 // indirect
 	github.com/loopholelabs/scale-signature-http v0.3.8 // indirect
-	github.com/loopholelabs/wasm-toolkit v0.0.3 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -238,6 +238,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
@@ -283,6 +285,12 @@ github.com/loopholelabs/scale-signature-http v0.3.8 h1:2McyHf/yngxBQZvQZ0NTDvAwL
 github.com/loopholelabs/scale-signature-http v0.3.8/go.mod h1:WoMckzVJEV9akY8vegZBJl7BmqjtVmtxanJHElqOGxI=
 github.com/loopholelabs/scalefile v0.1.9 h1:YXVJPI9OKQVnNj+al48yHl/3P8IUOOt9Vq9Aixu0iRI=
 github.com/loopholelabs/scalefile v0.1.9/go.mod h1:fPq4xcXpAzWErW1tqLTex2xIrHJ/iCRFb4et6+sbOvk=
+github.com/loopholelabs/wasm-toolkit v0.0.1-alpha h1:/YN+1hWhT+JhKGxUtilpEYmj6zgtwNTEp/c0XUjgPu4=
+github.com/loopholelabs/wasm-toolkit v0.0.1-alpha/go.mod h1:Miyk7GoMcik0hdlh6lYKvFUdS8DdQfZ3quGN00fijb8=
+github.com/loopholelabs/wasm-toolkit v0.0.1-alpha.0.20230424131309-6045b29b0852 h1:zbKNu0mS4FAVf9DUqd+XiCFXD4kl9zeTQJSN19JgIdg=
+github.com/loopholelabs/wasm-toolkit v0.0.1-alpha.0.20230424131309-6045b29b0852/go.mod h1:m4psyhcRJrwhDNsOlFKPCzvdZIPqQDsWZiJTMk9Qcbk=
+github.com/loopholelabs/wasm-toolkit v0.0.2 h1:VOZenzxKIiqFbSpNcxgor4FlaZVVQpiUql+/B17hzqU=
+github.com/loopholelabs/wasm-toolkit v0.0.2/go.mod h1:m4psyhcRJrwhDNsOlFKPCzvdZIPqQDsWZiJTMk9Qcbk=
 github.com/magiconair/properties v1.8.6 h1:5ibWZ6iY0NctNGWo87LalDlEZ6R41TqbbDamhfG/Qzo=
 github.com/magiconair/properties v1.8.6/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -366,6 +374,8 @@ github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
 github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
+github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
+github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/go.sum
+++ b/go.sum
@@ -236,8 +236,6 @@ github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4Dvx
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
-github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
@@ -285,12 +283,8 @@ github.com/loopholelabs/scale-signature-http v0.3.8 h1:2McyHf/yngxBQZvQZ0NTDvAwL
 github.com/loopholelabs/scale-signature-http v0.3.8/go.mod h1:WoMckzVJEV9akY8vegZBJl7BmqjtVmtxanJHElqOGxI=
 github.com/loopholelabs/scalefile v0.1.9 h1:YXVJPI9OKQVnNj+al48yHl/3P8IUOOt9Vq9Aixu0iRI=
 github.com/loopholelabs/scalefile v0.1.9/go.mod h1:fPq4xcXpAzWErW1tqLTex2xIrHJ/iCRFb4et6+sbOvk=
-github.com/loopholelabs/wasm-toolkit v0.0.1-alpha h1:/YN+1hWhT+JhKGxUtilpEYmj6zgtwNTEp/c0XUjgPu4=
-github.com/loopholelabs/wasm-toolkit v0.0.1-alpha/go.mod h1:Miyk7GoMcik0hdlh6lYKvFUdS8DdQfZ3quGN00fijb8=
-github.com/loopholelabs/wasm-toolkit v0.0.1-alpha.0.20230424131309-6045b29b0852 h1:zbKNu0mS4FAVf9DUqd+XiCFXD4kl9zeTQJSN19JgIdg=
-github.com/loopholelabs/wasm-toolkit v0.0.1-alpha.0.20230424131309-6045b29b0852/go.mod h1:m4psyhcRJrwhDNsOlFKPCzvdZIPqQDsWZiJTMk9Qcbk=
-github.com/loopholelabs/wasm-toolkit v0.0.2 h1:VOZenzxKIiqFbSpNcxgor4FlaZVVQpiUql+/B17hzqU=
-github.com/loopholelabs/wasm-toolkit v0.0.2/go.mod h1:m4psyhcRJrwhDNsOlFKPCzvdZIPqQDsWZiJTMk9Qcbk=
+github.com/loopholelabs/wasm-toolkit v0.0.3 h1:fsR/hmyOq3CxD36rWvM8kN7MxSpMqP5PgoqZx/X0pKw=
+github.com/loopholelabs/wasm-toolkit v0.0.3/go.mod h1:m4psyhcRJrwhDNsOlFKPCzvdZIPqQDsWZiJTMk9Qcbk=
 github.com/magiconair/properties v1.8.6 h1:5ibWZ6iY0NctNGWo87LalDlEZ6R41TqbbDamhfG/Qzo=
 github.com/magiconair/properties v1.8.6/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -372,8 +366,6 @@ github.com/spf13/afero v1.9.2/go.mod h1:iUV7ddyEEZPO5gA3zD4fJt6iStLlL+Lg4m2cihcD
 github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
 github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155UU=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
-github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
-github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
 github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
@@ -394,7 +386,7 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/subosito/gotenv v1.4.1 h1:jyEFiXpy21Wm81FBN71l9VoMMV8H8jG+qIK3GCpY6Qs=
 github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/tetratelabs/wazero v1.0.1 h1:xyWBoGyMjYekG3mEQ/W7xm9E05S89kJ/at696d/9yuc=

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -242,9 +242,11 @@ func GolangBuild(scaleFile *scalefile.ScaleFile, scaleFunc *scalefunc.ScaleFunc,
 	}
 
 	wconfig := wtoolkit.Otel_config{
-		Scale_api:   true,
-		Quickjs:     false,
-		Func_regexp: ".*",
+		Scale_api:       true,
+		Quickjs:         false,
+		Func_regexp:     ".*",
+		Watch_variables: debugOpts.WatchVariables,
+		Language:        "go",
 	}
 	err = setScaleFunc(scaleFunc, path.Join(cmd.Dir, "scale.wasm"), wconfig, debugOpts)
 
@@ -392,9 +394,11 @@ func RustBuild(scaleFile *scalefile.ScaleFile, scaleFunc *scalefunc.ScaleFunc, c
 	}
 
 	wconfig := wtoolkit.Otel_config{
-		Scale_api:   true,
-		Quickjs:     false,
-		Func_regexp: ".*",
+		Scale_api:       true,
+		Quickjs:         false,
+		Func_regexp:     ".*",
+		Watch_variables: debugOpts.WatchVariables,
+		Language:        "rust",
 	}
 	err = setScaleFunc(scaleFunc, path.Join(cmd.Dir, outputPath), wconfig, debugOpts)
 
@@ -562,9 +566,11 @@ func TypeScriptBuild(scaleFile *scalefile.ScaleFile, scaleFunc *scalefunc.ScaleF
 	}
 
 	wconfig := wtoolkit.Otel_config{
-		Scale_api:   true,
-		Quickjs:     true,
-		Func_regexp: "^\\$JS_CallInternal$",
+		Scale_api:       true,
+		Quickjs:         true,
+		Func_regexp:     "^\\$JS_CallInternal$",
+		Watch_variables: debugOpts.WatchVariables,
+		Language:        "javascript",
 	}
 	err = setScaleFunc(scaleFunc, path.Join(buildDir, "index.wasm"), wconfig, debugOpts)
 

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -214,6 +214,19 @@ func GolangBuild(scaleFile *scalefile.ScaleFile, scaleFunc *scalefunc.ScaleFunc,
 		return nil, fmt.Errorf("unable to compile scale function: %w", err)
 	}
 
+	if debugOpts.Tracing {
+		// Make sure we have best options for tinygo
+		debugTinygoArgs := make([]string, 0)
+		for _, a := range tinygoArgs {
+			if a == "--no-debug" {
+				// Remove the flag. Using this flag when we're doing debugging/tracing doesn't make much sense.
+			} else {
+				debugTinygoArgs = append(debugTinygoArgs, a)
+			}
+		}
+		tinygoArgs = debugTinygoArgs
+	}
+
 	tinygoArgs = append([]string{"build", "-o", "scale.wasm", "-target=wasi"}, tinygoArgs...)
 	tinygoArgs = append(tinygoArgs, "main.go")
 
@@ -342,6 +355,19 @@ func RustBuild(scaleFile *scalefile.ScaleFile, scaleFunc *scalefunc.ScaleFunc, c
 	err = file.Close()
 	if err != nil {
 		return nil, fmt.Errorf("unable to close scale source file: %w", err)
+	}
+
+	if debugOpts.Tracing {
+		// Make sure we have best options for cargo
+		debugCargoArgs := make([]string, 0)
+		for _, a := range cargoArgs {
+			if a == "--release" {
+				// Remove the flag. Using this flag when we're doing debugging/tracing doesn't make much sense.
+			} else {
+				debugCargoArgs = append(debugCargoArgs, a)
+			}
+		}
+		cargoArgs = debugCargoArgs
 	}
 
 	cargoArgs = append([]string{"build", "--target", "wasm32-wasi", "--manifest-path", "Cargo.toml"}, cargoArgs...)

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strings"
 
 	"github.com/loopholelabs/scale/go/compile"
 	rustCompile "github.com/loopholelabs/scale/rust/compile"
@@ -220,11 +221,14 @@ func GolangBuild(scaleFile *scalefile.ScaleFile, scaleFunc *scalefunc.ScaleFunc,
 		for _, a := range tinygoArgs {
 			if a == "--no-debug" {
 				// Remove the flag. Using this flag when we're doing debugging/tracing doesn't make much sense.
+			} else if strings.HasPrefix(a, "-opt=") {
+				// Remove any opt flag
 			} else {
 				debugTinygoArgs = append(debugTinygoArgs, a)
 			}
 		}
 		tinygoArgs = debugTinygoArgs
+		tinygoArgs = append(tinygoArgs, "-opt=0")
 	}
 
 	tinygoArgs = append([]string{"build", "-o", "scale.wasm", "-target=wasi"}, tinygoArgs...)

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -221,11 +221,11 @@ func GolangBuild(scaleFile *scalefile.ScaleFile, scaleFunc *scalefunc.ScaleFunc,
 		return nil, fmt.Errorf("unable to compile scale function: %w", err)
 	}
 
-	data, err := os.ReadFile(path.Join(cmd.Dir, "scale.wasm"))
+	err = setScaleFunc(scaleFunc, path.Join(cmd.Dir, "scale.wasm"))
+
 	if err != nil {
 		return nil, fmt.Errorf("unable to read compiled wasm file: %w", err)
 	}
-	scaleFunc.Function = data
 
 	return scaleFunc, nil
 }
@@ -353,11 +353,11 @@ func RustBuild(scaleFile *scalefile.ScaleFile, scaleFunc *scalefunc.ScaleFunc, c
 		}
 	}
 
-	data, err := os.ReadFile(path.Join(cmd.Dir, outputPath))
+	err = setScaleFunc(scaleFunc, path.Join(cmd.Dir, outputPath))
+
 	if err != nil {
 		return nil, fmt.Errorf("unable to read compiled wasm file: %w", err)
 	}
-	scaleFunc.Function = data
 
 	return scaleFunc, nil
 }
@@ -518,12 +518,23 @@ func TypeScriptBuild(scaleFile *scalefile.ScaleFile, scaleFunc *scalefunc.ScaleF
 		return nil, fmt.Errorf("unable to compile scale function: %w", err)
 	}
 
-	data, err := os.ReadFile(path.Join(buildDir, "index.wasm"))
+	err = setScaleFunc(scaleFunc, path.Join(buildDir, "index.wasm"))
+
 	if err != nil {
 		return nil, fmt.Errorf("unable to read compiled wasm file: %w", err)
 	}
 
-	scaleFunc.Function = data
-
 	return scaleFunc, nil
+}
+
+func setScaleFunc(scaleFunc *scalefunc.ScaleFunc, wasmfile string) error {
+	data, err := os.ReadFile(wasmfile)
+	if err != nil {
+		return err
+	}
+
+	// TODO: Optimize wasm, add tracing, logging, etc etc
+
+	scaleFunc.Function = data
+	return nil
 }

--- a/pkg/build/jslinksource.go
+++ b/pkg/build/jslinksource.go
@@ -1,0 +1,24 @@
+/*
+	Copyright 2023 Loophole Labs
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		   http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package build
+
+import (
+	_ "embed"
+)
+
+//go:embed releases/jslinksource.wasm
+var jslinksource []byte


### PR DESCRIPTION
This adds the option to create tracing/debug builds of scale functions. This is done using the --otel flag, and optionally the --watch flag to watch globals within the trace.

* Go - We remove the `--no-debug` flag to tinygo, and set `--opt=0` to remove any optimizations
* Rust - We remove the `--release` flag from the cargo options
* Typescript - We remove the "optimize: true" flag in the `package.json`. We also use wasm addSource to inject the js source into a wasm, rather than using the usual `jsbuilder` binary which would also do wizer optimization.