### PR TITLE
Fix: QoL Issues and Minor Bugs

### DIFF
--- a/cmd/function/build.go
+++ b/cmd/function/build.go
@@ -118,7 +118,10 @@ func BuildCmd(hidden bool) command.SetupCommand[*config.Config] {
 
 					sig, err := sts.Get(sf.Signature.Name, sf.Signature.Tag, sf.Signature.Organization, "")
 					if err != nil {
-						return fmt.Errorf("failed to get signature %s:%s: %w", sf.Signature.Name, sf.Signature.Tag, err)
+						return fmt.Errorf("failed to get signature local/%s:%s: %w", sf.Signature.Name, sf.Signature.Tag, err)
+					}
+					if sig == nil {
+						return fmt.Errorf("signature local/%s:%s not found", sf.Signature.Name, sf.Signature.Tag)
 					}
 
 					signatureSchema = sig.Schema
@@ -145,7 +148,6 @@ func BuildCmd(hidden bool) command.SetupCommand[*config.Config] {
 
 				out := ch.Printer.Out()
 
-				end := ch.Printer.PrintProgress(fmt.Sprintf("Building scale function local/%s:%s...", sf.Name, sf.Tag))
 				var scaleFunc *scalefunc.Schema
 				switch scalefunc.Language(sf.Language) {
 				case scalefunc.Go:
@@ -176,10 +178,8 @@ func BuildCmd(hidden bool) command.SetupCommand[*config.Config] {
 					}
 					scaleFunc, err = build.LocalRust(opts)
 				default:
-					end()
 					return fmt.Errorf("language %s is not supported for local builds", sf.Language)
 				}
-				end()
 				if err != nil {
 					return fmt.Errorf("failed to build scale function: %w", err)
 				}

--- a/cmd/function/export.go
+++ b/cmd/function/export.go
@@ -88,13 +88,13 @@ func ExportCmd() command.SetupCommand[*config.Config] {
 					outputPath = path.Join(wd, outputPath)
 				}
 
-				oInfo, err := os.Stat(output)
+				oInfo, err := os.Stat(outputPath)
 				if err != nil {
-					return fmt.Errorf("failed to stat output path %s: %w", output, err)
+					return fmt.Errorf("failed to stat output path %s: %w", outputPath, err)
 				}
 
 				if !oInfo.IsDir() {
-					return fmt.Errorf("output path %s is not a directory", output)
+					return fmt.Errorf("output path %s is not a directory", outputPath)
 				}
 
 				if outputName == "" {
@@ -102,27 +102,27 @@ func ExportCmd() command.SetupCommand[*config.Config] {
 					if raw {
 						suffix = "wasm"
 					}
-					output = path.Join(output, fmt.Sprintf("%s-%s-%s.%s", parsed.Organization, parsed.Name, parsed.Tag, suffix))
+					outputPath = path.Join(outputPath, fmt.Sprintf("%s-%s-%s.%s", parsed.Organization, parsed.Name, parsed.Tag, suffix))
 				} else {
-					output = path.Join(output, outputName)
+					outputPath = path.Join(outputPath, outputName)
 				}
 
 				if raw {
-					err = os.WriteFile(output, e.Schema.Function, 0644)
+					err = os.WriteFile(outputPath, e.Schema.Function, 0644)
 				} else {
-					err = os.WriteFile(output, e.Schema.Encode(), 0644)
+					err = os.WriteFile(outputPath, e.Schema.Encode(), 0644)
 				}
 				if err != nil {
-					return fmt.Errorf("failed to write function to %s: %w", output, err)
+					return fmt.Errorf("failed to write function to %s: %w", outputPath, err)
 				}
 
 				if ch.Printer.Format() == printer.Human {
-					ch.Printer.Printf("Exported scale function %s to %s\n", printer.BoldGreen(fmt.Sprintf("%s/%s:%s", parsed.Organization, parsed.Name, parsed.Tag)), printer.BoldBlue(output))
+					ch.Printer.Printf("Exported scale function %s to %s\n", printer.BoldGreen(fmt.Sprintf("%s/%s:%s", parsed.Organization, parsed.Name, parsed.Tag)), printer.BoldBlue(outputPath))
 					return nil
 				}
 
 				return ch.Printer.PrintResource(map[string]string{
-					"destination": output,
+					"destination": outputPath,
 					"org":         parsed.Organization,
 					"name":        parsed.Name,
 					"tag":         parsed.Tag,

--- a/cmd/function/export.go
+++ b/cmd/function/export.go
@@ -90,10 +90,12 @@ func ExportCmd() command.SetupCommand[*config.Config] {
 
 				oInfo, err := os.Stat(outputPath)
 				if err != nil {
-					return fmt.Errorf("failed to stat output path %s: %w", outputPath, err)
-				}
-
-				if !oInfo.IsDir() {
+					ch.Printer.Printf("Creating output directory %s\n", printer.BoldBlue(outputPath))
+					err = os.MkdirAll(outputPath, 0755)
+					if err != nil {
+						return fmt.Errorf("failed to create output directory %s: %w", outputPath, err)
+					}
+				} else if !oInfo.IsDir() {
 					return fmt.Errorf("output path %s is not a directory", outputPath)
 				}
 

--- a/cmd/signature/export.go
+++ b/cmd/signature/export.go
@@ -71,7 +71,7 @@ func ExportCmd() command.SetupCommand[*config.Config] {
 				kind := args[2]
 				output := args[3]
 
-				kindString := "guest"
+				var kindString string
 				switch kind {
 				case "guest":
 					switch scalefunc.Language(language) {

--- a/cmd/signature/new.go
+++ b/cmd/signature/new.go
@@ -51,7 +51,7 @@ func NewCmd(hidden bool) command.SetupCommand[*config.Config] {
 					}
 					sourceDir = path.Join(wd, sourceDir)
 				}
-				err := os.WriteFile(path.Join(sourceDir, fmt.Sprintf("scale.signature")), []byte(template.SignatureFile), 0644)
+				err := os.WriteFile(path.Join(sourceDir, "scale.signature"), []byte(template.SignatureFile), 0644)
 				if err != nil {
 					return fmt.Errorf("error writing signature: %w", err)
 				}
@@ -62,7 +62,7 @@ func NewCmd(hidden bool) command.SetupCommand[*config.Config] {
 				}
 
 				return ch.Printer.PrintResource(map[string]string{
-					"path": path.Join(directory, fmt.Sprintf("scale.signature")),
+					"path": path.Join(directory, "scale.signature"),
 				})
 			},
 		}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/loopholelabs/auth v0.2.47
 	github.com/loopholelabs/cmdutils v0.1.4
 	github.com/loopholelabs/releaser v0.1.1
-	github.com/loopholelabs/scale v0.4.0
+	github.com/loopholelabs/scale v0.4.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8

--- a/go.mod
+++ b/go.mod
@@ -12,13 +12,14 @@ require (
 	github.com/loopholelabs/auth v0.2.47
 	github.com/loopholelabs/cmdutils v0.1.4
 	github.com/loopholelabs/releaser v0.1.1
-	github.com/loopholelabs/scale v0.4.1
+	github.com/loopholelabs/scale v0.4.2
+	github.com/mattn/go-isatty v0.0.19
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1
 	github.com/posthog/posthog-go v0.0.0-20230801140217-d607812dee69
-	github.com/rs/zerolog v1.30.0
+	github.com/rs/zerolog v1.31.0
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.16.0
@@ -66,7 +67,6 @@ require (
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -291,8 +291,8 @@ github.com/loopholelabs/polyglot v1.1.3 h1:WUTcSZ2TQ1lv7CZ4I9nHFBUjf0hKJN+Yfz1rZ
 github.com/loopholelabs/polyglot v1.1.3/go.mod h1:EA88BEkIluKHAWxhyOV88xXz68YkRdo9IzZ+1dj+7Ao=
 github.com/loopholelabs/releaser v0.1.1 h1:o8Z4jIR4TcaSRiwFpAGIJSAkAUOxlXL1ML3EscGqxDU=
 github.com/loopholelabs/releaser v0.1.1/go.mod h1:51hV+lDDYeJNzeVOZCQnGS5cJN8ODg/V5AxYtiL67UA=
-github.com/loopholelabs/scale v0.4.1 h1:vhw9SkADb6ro0sQfVbvVo1ZXicgKodj+EXuYqJGg5TQ=
-github.com/loopholelabs/scale v0.4.1/go.mod h1:3dsQQCsIbJ5oOEpI/53jVBuDPYyi/Z85ZjroPDTKIzw=
+github.com/loopholelabs/scale v0.4.2 h1:uIsUSeG0cPxTyt7GxJc+pY23QlBUAH5GsIobz6o/T5k=
+github.com/loopholelabs/scale v0.4.2/go.mod h1:3dsQQCsIbJ5oOEpI/53jVBuDPYyi/Z85ZjroPDTKIzw=
 github.com/loopholelabs/scale-signature-interfaces v0.1.7 h1:aOJJZpCKn/Q5Q0Gj+/Q6c7/iABEbojjbCzIqw7Mxyi0=
 github.com/loopholelabs/scale-signature-interfaces v0.1.7/go.mod h1:3XLMjJjBf5lYxMtNKk+2XAWye4UyrkvUBJ9L6x2QCAk=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -305,11 +305,9 @@ github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJ
 github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsIW75CHf65OeIOkyKbteujpZVXDpWK6YGZbxE=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
-github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
-github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
@@ -355,8 +353,8 @@ github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
-github.com/rs/zerolog v1.30.0 h1:SymVODrcRsaRaSInD9yQtKbtWqwsfoPcRff/oRXLj4c=
-github.com/rs/zerolog v1.30.0/go.mod h1:/tk+P47gFdPXq4QYjvCmT5/Gsug2nagsFWBWhAiSi1w=
+github.com/rs/zerolog v1.31.0 h1:FcTR3NnLWW+NnTwwhFWiJSZr4ECLpqCm6QsEnyvbV4A=
+github.com/rs/zerolog v1.31.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
@@ -593,8 +591,6 @@ golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -291,8 +291,8 @@ github.com/loopholelabs/polyglot v1.1.3 h1:WUTcSZ2TQ1lv7CZ4I9nHFBUjf0hKJN+Yfz1rZ
 github.com/loopholelabs/polyglot v1.1.3/go.mod h1:EA88BEkIluKHAWxhyOV88xXz68YkRdo9IzZ+1dj+7Ao=
 github.com/loopholelabs/releaser v0.1.1 h1:o8Z4jIR4TcaSRiwFpAGIJSAkAUOxlXL1ML3EscGqxDU=
 github.com/loopholelabs/releaser v0.1.1/go.mod h1:51hV+lDDYeJNzeVOZCQnGS5cJN8ODg/V5AxYtiL67UA=
-github.com/loopholelabs/scale v0.4.0 h1:40x4q+Ch71YMMJBJFJo+2qB1XS95N8gbpjUg3U1Icpc=
-github.com/loopholelabs/scale v0.4.0/go.mod h1:3dsQQCsIbJ5oOEpI/53jVBuDPYyi/Z85ZjroPDTKIzw=
+github.com/loopholelabs/scale v0.4.1 h1:vhw9SkADb6ro0sQfVbvVo1ZXicgKodj+EXuYqJGg5TQ=
+github.com/loopholelabs/scale v0.4.1/go.mod h1:3dsQQCsIbJ5oOEpI/53jVBuDPYyi/Z85ZjroPDTKIzw=
 github.com/loopholelabs/scale-signature-interfaces v0.1.7 h1:aOJJZpCKn/Q5Q0Gj+/Q6c7/iABEbojjbCzIqw7Mxyi0=
 github.com/loopholelabs/scale-signature-interfaces v0.1.7/go.mod h1:3XLMjJjBf5lYxMtNKk+2XAWye4UyrkvUBJ9L6x2QCAk=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=


### PR DESCRIPTION
This PR fixes various QoL issues and Minor Bugs. 

QoL Fixes:
- The `scale function build` command will now properly output build progress to the terminal
- The `scale function run` command will now recognize `stdin` input and allow piping in json input instead of starting a webserver (#41)
- The `scale function export` command will now create the given output directory if it does not already exist (#39)

Bug Fixes: 
- The `scale function build` command will no longer return a panic when the signature in the scalefile cannot be found (#44)
- The `scale function run` command will no longer return an error for valid input where the signature contains multiple embedded models 

Dependencies:
- Bumping `zerolog` to `v1.31.0`